### PR TITLE
Update ed25519-dalek 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["libolm-compat"]
-# rand has renamed the feature to js but we're still using rand 0.7 since the
-# dalek crates depend on that version.
-# Make sure to change the feature once we bump rand and the dalek crates.
-js = ["rand/wasm-bindgen"]
 strict-signatures = []
 libolm-compat = []
 # The low-level-api feature exposes extra APIs that are only useful in advanced
@@ -43,13 +39,13 @@ hmac = "0.12.1"
 matrix-pickle = { version = "0.1.0" }
 pkcs7 = "0.3.0"
 prost = "0.11.0"
-rand = "0.7.3"
+rand = "0.8.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = "0.10.2"
 subtle = "2.4.1"
 thiserror = "1.0.30"
-x25519-dalek = { version = "2.0.0-pre.1", features = ["serde", "reusable_secrets","static_secrets"] }
+x25519-dalek = { version = "2.0.0-rc.2", features = ["serde", "reusable_secrets", "static_secrets"] }
 zeroize = "1.3.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ aes = "0.8.1"
 arrayvec = { version = "0.7.2", features = ["serde"] }
 base64 = "0.13.0"
 cbc = { version = "0.1.2", features = ["std"] }
-ed25519-dalek = { version = "1.0.1", default-features = false, features = [
-    "rand",
+ed25519-dalek = { version = "2.0.0-rc.2", default-features = false, features = [
+    "rand_core",
     "std",
     "serde",
 ] }
@@ -49,7 +49,7 @@ serde_json = "1.0.79"
 sha2 = "0.10.2"
 subtle = "2.4.1"
 thiserror = "1.0.30"
-x25519-dalek = { version = "1.2.0", features = ["serde", "reusable_secrets"] }
+x25519-dalek = { version = "2.0.0-pre.1", features = ["serde", "reusable_secrets","static_secrets"] }
 zeroize = "1.3.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["libolm-compat"]
+default = []
 strict-signatures = []
 libolm-compat = []
 # The low-level-api feature exposes extra APIs that are only useful in advanced

--- a/src/cipher/key.rs
+++ b/src/cipher/key.rs
@@ -43,7 +43,6 @@ impl ExpandedKeys {
         Self::new_helper(message_key, Self::MEGOLM_HKDF_INFO)
     }
 
-    #[cfg(feature = "libolm-compat")]
     fn new_pickle(pickle_key: &[u8]) -> Self {
         Self::new_helper(pickle_key, b"Pickle")
     }
@@ -80,7 +79,6 @@ impl CipherKeys {
         Self::from_expanded_keys(expanded_keys)
     }
 
-    #[cfg(feature = "libolm-compat")]
     pub fn new_pickle(pickle_key: &[u8]) -> Self {
         let expanded_keys = ExpandedKeys::new_pickle(pickle_key);
 

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -105,7 +105,6 @@ impl Cipher {
         Self { keys }
     }
 
-    #[cfg(feature = "libolm-compat")]
     pub fn new_pickle(key: &[u8]) -> Self {
         let keys = CipherKeys::new_pickle(key);
 

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -19,7 +19,7 @@ use hmac::digest::MacError;
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use thiserror::Error;
-use zeroize::Zeroize;
+// use zeroize::Zeroize;
 
 use super::{
     default_config,

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -160,7 +160,7 @@ impl Account {
     ) -> Session {
         let rng = thread_rng();
 
-        let base_key = ReusableSecret::new(rng);
+        let base_key = ReusableSecret::random_from_rng(rng);
         let public_base_key = Curve25519PublicKey::from(&base_key);
 
         let shared_secret = Shared3DHSecret::new(

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -423,16 +423,8 @@ mod libolm {
     use matrix_pickle::{Decode, DecodeError};
     use zeroize::Zeroize;
 
-    use super::{
-        fallback_keys::{FallbackKey, FallbackKeys},
-        one_time_keys::OneTimeKeys,
-        Account,
-    };
-    use crate::{
-        types::{Curve25519Keypair, Curve25519SecretKey},
-        utilities::LibolmEd25519Keypair,
-        Ed25519Keypair, KeyId,
-    };
+    use super::fallback_keys::FallbackKey;
+    use crate::{types::Curve25519SecretKey, utilities::LibolmEd25519Keypair, KeyId};
 
     #[derive(Debug, Zeroize, Decode)]
     #[zeroize(drop)]
@@ -546,7 +538,7 @@ mod test {
             messages::{OlmMessage, PreKeyMessage},
             AccountPickle,
         },
-        run_corpus, Curve25519PublicKey as PublicKey,
+        Curve25519PublicKey as PublicKey,
     };
 
     const PICKLE_KEY: [u8; 32] = [0u8; 32];

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -30,7 +30,7 @@ use receiver_chain::ReceiverChain;
 use root_key::RemoteRootKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zeroize::Zeroize;
+// use zeroize::Zeroize;
 
 use super::{
     session_config::Version,

--- a/src/olm/shared_secret.rs
+++ b/src/olm/shared_secret.rs
@@ -129,7 +129,7 @@ mod test {
         let rng = thread_rng();
 
         let alice_identity = StaticSecret::new();
-        let alice_one_time = ReusableSecret::new(rng);
+        let alice_one_time = ReusableSecret::random_from_rng(rng);
 
         let bob_identity = StaticSecret::new();
         let bob_one_time = StaticSecret::new();

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -223,7 +223,7 @@ impl Sas {
     pub fn new() -> Self {
         let rng = thread_rng();
 
-        let secret_key = EphemeralSecret::new(rng);
+        let secret_key = EphemeralSecret::random_from_rng(rng);
         let public_key = Curve25519PublicKey::from(&secret_key);
 
         Self { secret_key, public_key }

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -565,6 +565,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(feature = "libolm-compat")]
     #[test]
     fn calculate_mac_invalid_base64() -> Result<()> {
         let mut olm = OlmSas::new();

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -32,7 +32,7 @@ impl Curve25519SecretKey {
     pub fn new() -> Self {
         let rng = thread_rng();
 
-        Self(Box::new(StaticSecret::new(rng)))
+        Self(Box::new(StaticSecret::random_from_rng(rng)))
     }
 
     /// Create a `Curve25519SecretKey` from the given slice of bytes.

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -22,7 +22,7 @@ use ed25519_dalek::{
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zeroize::Zeroize;
+// use szeroize::Zeroize;
 
 use crate::{
     utilities::{base64_decode, base64_encode},

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -17,15 +17,17 @@ use std::fmt::Display;
 #[cfg(not(fuzzing))]
 use ed25519_dalek::Verifier;
 use ed25519_dalek::{
-    ExpandedSecretKey, Keypair, PublicKey, SecretKey, Signature, PUBLIC_KEY_LENGTH,
-    SIGNATURE_LENGTH,
+    Signature, Signer, SigningKey, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
 };
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::Zeroize;
 
-use crate::utilities::{base64_decode, base64_encode};
+use crate::{
+    utilities::{base64_decode, base64_encode},
+    KeyError,
+};
 
 /// Error type describing signature verification failures.
 #[derive(Debug, Error)]
@@ -43,7 +45,7 @@ pub enum SignatureError {
 #[serde(try_from = "Ed25519KeypairPickle")]
 #[serde(into = "Ed25519KeypairPickle")]
 pub struct Ed25519Keypair {
-    secret_key: SecretKeys,
+    secret_key: SigningKey,
     public_key: Ed25519PublicKey,
 }
 
@@ -51,15 +53,21 @@ impl Ed25519Keypair {
     /// Create a new, random, `Ed25519Keypair`.
     pub fn new() -> Self {
         let mut rng = thread_rng();
-        let keypair = Keypair::generate(&mut rng);
+        let signing = SigningKey::generate(&mut rng);
+        let verifying = signing.verifying_key();
+        Self { secret_key: signing, public_key: Ed25519PublicKey(verifying) }
+    }
 
-        Self { secret_key: keypair.secret.into(), public_key: Ed25519PublicKey(keypair.public) }
+    pub fn from_secret_key(bytes: &[u8; 32]) -> Self {
+        let signing = SigningKey::from_bytes(bytes);
+        let verifying = signing.verifying_key();
+        Self { secret_key: signing, public_key: Ed25519PublicKey(verifying) }
     }
 
     #[cfg(feature = "libolm-compat")]
     pub(crate) fn from_expanded_key(secret_key: &[u8; 64]) -> Result<Self, crate::KeyError> {
-        let secret_key = ExpandedSecretKey::from_bytes(secret_key).map_err(SignatureError::from)?;
-        let public_key = Ed25519PublicKey(PublicKey::from(&secret_key));
+        let secret_key = SigningKey::from_bytes(secret_key).map_err(SignatureError::from)?;
+        let public_key = Ed25519PublicKey(VerifyingKey::from(&secret_key));
 
         Ok(Self { secret_key: secret_key.into(), public_key })
     }
@@ -71,7 +79,9 @@ impl Ed25519Keypair {
 
     /// Sign the given message with our secret key.
     pub fn sign(&self, message: &[u8]) -> Ed25519Signature {
-        self.secret_key.sign(message, &self.public_key())
+        let result = self.secret_key.try_sign(message);
+        // TODO: Change method to return Result -- ed25519-dalek now returns a result.
+        Ed25519Signature(result.map_err(|e| format!("signing failed: {}", e)).unwrap())
     }
 }
 
@@ -84,124 +94,131 @@ impl Default for Ed25519Keypair {
 /// An Ed25519 secret key, used to create digital signatures.
 #[derive(Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct Ed25519SecretKey(Box<SecretKey>);
-
-impl Ed25519SecretKey {
-    /// Create a new random `Ed25519SecretKey`.
-    pub fn new() -> Self {
-        let mut rng = thread_rng();
-        let key = Box::new(SecretKey::generate(&mut rng));
-
-        Self(key)
-    }
-
-    /// Get the byte representation of the secret key.
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        self.0.as_bytes()
-    }
-
-    /// Try to create a `Ed25519SecretKey` from a slice of bytes.
-    pub fn from_slice(bytes: &[u8]) -> Result<Self, crate::KeyError> {
-        let key = Box::new(SecretKey::from_bytes(bytes).map_err(SignatureError::from)?);
-
-        Ok(Self(key))
-    }
-
-    /// Convert the secret key to a base64 encoded string.
-    ///
-    /// This can be useful if the secret key needs to be sent over the network
-    /// or persisted.
-    ///
-    /// **Warning**: The string should be zeroized after it has been used,
-    /// otherwise an unintentional copy of the key might exist in memory.
-    pub fn to_base64(&self) -> String {
-        base64_encode(self.as_bytes())
-    }
-
-    /// Try to create a `Ed25519SecretKey` from a base64 encoded string.
-    pub fn from_base64(key: &str) -> Result<Self, crate::KeyError> {
-        let mut bytes = base64_decode(key)?;
-        let key = Self::from_slice(&bytes);
-
-        bytes.zeroize();
-
-        key
-    }
-
-    /// Get the public key that matches this `Ed25519SecretKey`.
-    pub fn public_key(&self) -> Ed25519PublicKey {
-        Ed25519PublicKey(PublicKey::from(self.0.as_ref()))
-    }
-
-    /// Sign the given slice of bytes with this `Ed25519SecretKey`.
-    ///
-    /// The signature can be verified using the public key.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use vodozemac::{Ed25519SecretKey, Ed25519PublicKey};
-    ///
-    /// let secret = Ed25519SecretKey::new();
-    /// let message = "It's dangerous to go alone";
-    ///
-    /// let signature = secret.sign(message.as_bytes());
-    ///
-    /// let public_key = secret.public_key();
-    ///
-    /// public_key.verify(message.as_bytes(), &signature).expect("The signature has to be valid");
-    /// ```
-    pub fn sign(&self, message: &[u8]) -> Ed25519Signature {
-        let expanded = ExpandedSecretKey::from(self.0.as_ref());
-        Ed25519Signature(expanded.sign(message, &self.public_key().0))
-    }
+pub struct Ed25519SecretKey {
+    keypair: Ed25519Keypair,
 }
 
-impl Default for Ed25519SecretKey {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// impl Ed25519SecretKey {
+//     /// Create a new random `Ed25519SecretKey`.
+//     pub fn new() -> Self {
+//         Self { keypair: Ed25519Keypair::new() }
+//     }
 
-#[derive(Serialize, Deserialize)]
-enum SecretKeys {
-    Normal(Box<SecretKey>),
-    Expanded(Box<ExpandedSecretKey>),
-}
+//     /// Get the byte representation of the secret key.
+//     pub fn as_bytes(&self) -> [u8; 32] {
+//         self.keypair.secret_key.to_bytes() // TODO: Verify Lifetime
+//
+//     }
 
-impl SecretKeys {
-    fn public_key(&self) -> Ed25519PublicKey {
-        match &self {
-            SecretKeys::Normal(k) => Ed25519PublicKey(PublicKey::from(k.as_ref())),
-            SecretKeys::Expanded(k) => Ed25519PublicKey(PublicKey::from(k.as_ref())),
-        }
-    }
+//     /// Try to create a `Ed25519SecretKey` from a slice of bytes.
+//     pub fn from_slice(bytes: &[u8]) -> Result<Self, KeyError> {
+//         if bytes.len() != 32 {
+//             return Err(KeyError::InvalidKeyLength(bytes.len()));
+//         }
 
-    fn sign(&self, message: &[u8], public_key: &Ed25519PublicKey) -> Ed25519Signature {
-        let signature = match &self {
-            SecretKeys::Normal(k) => {
-                let expanded = ExpandedSecretKey::from(k.as_ref());
-                expanded.sign(message.as_ref(), &public_key.0)
-            }
-            SecretKeys::Expanded(k) => k.sign(message.as_ref(), &public_key.0),
-        };
+//         match bytes.try_into() {
+//             Ok(b) => Ok(Self { keypair: Ed25519Keypair::from_secret_key(b) }),
+//             Err(_) => Err(KeyError::InvalidKeyLength(32)),
+//         }
 
-        Ed25519Signature(signature)
-    }
-}
+//         // let key = Ed25519Keypair::from_secret_key(&);
+//     }
+
+//     /// Convert the secret key to a base64 encoded string.
+//     ///
+//     /// This can be useful if the secret key needs to be sent over the network
+//     /// or persisted.
+//     ///
+//     /// **Warning**: The string should be zeroized after it has been used,
+//     /// otherwise an unintentional copy of the key might exist in memory.
+//     pub fn to_base64(&self) -> String {
+//         base64_encode(self.as_bytes())
+//     }
+
+//     /// Try to create a `Ed25519SecretKey` from a base64 encoded string.
+//     pub fn from_base64(key: &str) -> Result<Self, KeyError> {
+//         let mut bytes = base64_decode(key)?;
+//         let key = Self::from_slice(&bytes);
+
+//         bytes.zeroize();
+
+//         key
+//     }
+
+//     /// Get the public key that matches this `Ed25519SecretKey`.
+//     pub fn public_key(&self) -> Ed25519PublicKey {
+//         Ed25519PublicKey(self.keypair.secret_key.verifying_key())
+//         // TODO: Add result type to return
+//     }
+
+//     /// Sign the given slice of bytes with this `Ed25519SecretKey`.
+//     ///
+//     /// The signature can be verified using the public key.
+//     ///
+//     /// # Examples
+//     ///
+//     /// ```
+//     /// use vodozemac::{Ed25519SecretKey, Ed25519PublicKey};
+//     ///
+//     /// let secret = Ed25519SecretKey::new();
+//     /// let message = "It's dangerous to go alone";
+//     ///
+//     /// let signature = secret.sign(message.as_bytes());
+//     ///
+//     /// let public_key = secret.public_key();
+//     ///
+//     /// public_key.verify(message.as_bytes(), &signature).expect("The signature has to be valid");
+//     /// ```
+//     pub fn sign(&self, message: &[u8]) -> Ed25519Signature {
+//         self.keypair.sign(message)
+//     }
+// }
+
+// impl Default for Ed25519SecretKey {
+//     fn default() -> Self {
+//         Self::new()
+//     }
+// }
+
+// #[derive(Serialize, Deserialize)]
+// enum SecretKeys {
+//     Normal(Box<SecretKey>),
+//     Expanded(Box<ExpandedSecretKey>),
+// }
+
+// impl SecretKeys {
+//     fn public_key(&self) -> Ed25519PublicKey {
+//         match &self {
+//             SecretKeys::Normal(k) => Ed25519PublicKey(PublicKey::from(k.as_ref())),
+//             SecretKeys::Expanded(k) => Ed25519PublicKey(PublicKey::from(k.as_ref())),
+//         }
+//     }
+
+//     fn sign(&self, message: &[u8], public_key: &Ed25519PublicKey) -> Ed25519Signature {
+//         let signature = match &self {
+//             SecretKeys::Normal(k) => {
+//                 let expanded = ExpandedSecretKey::from(k.as_ref());
+//                 expanded.sign(message.as_ref(), &public_key.0)
+//             }
+//             SecretKeys::Expanded(k) => k.sign(message.as_ref(), &public_key.0),
+//         };
+
+//         Ed25519Signature(signature)
+//     }
+// }
 
 /// An Ed25519 public key, used to verify digital signatures.
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct Ed25519PublicKey(PublicKey);
+pub struct Ed25519PublicKey(VerifyingKey);
 
 impl Ed25519PublicKey {
     /// The number of bytes a Ed25519 public key has.
     pub const LENGTH: usize = PUBLIC_KEY_LENGTH;
 
     /// Try to create a `Ed25519PublicKey` from a slice of bytes.
-    pub fn from_slice(bytes: &[u8]) -> Result<Self, crate::KeyError> {
-        Ok(Self(PublicKey::from_bytes(bytes).map_err(SignatureError::from)?))
+    pub fn from_slice(bytes: &[u8; 32]) -> Result<Self, KeyError> {
+        Ok(Self(VerifyingKey::from_bytes(bytes).map_err(SignatureError::from)?))
     }
 
     /// View this public key as a byte array.
@@ -211,9 +228,13 @@ impl Ed25519PublicKey {
 
     /// Instantiate a Ed25519PublicKey public key from an unpadded base64
     /// representation.
-    pub fn from_base64(base64_key: &str) -> Result<Self, crate::KeyError> {
+    pub fn from_base64(base64_key: &str) -> Result<Self, KeyError> {
         let key = base64_decode(base64_key)?;
-        Self::from_slice(&key)
+
+        if key.len() != 32 {
+            return Err(KeyError::InvalidKeyLength(32));
+        }
+        Self::from_slice(&key.try_into().map_err(|_| KeyError::Unknown)?)
     }
 
     /// Serialize a Ed25519PublicKey public key to an unpadded base64
@@ -319,21 +340,22 @@ impl std::fmt::Debug for Ed25519Signature {
 
 impl Clone for Ed25519Keypair {
     fn clone(&self) -> Self {
-        let secret_key: Result<SecretKeys, _> = match &self.secret_key {
-            SecretKeys::Normal(k) => SecretKey::from_bytes(k.as_bytes()).map(|k| k.into()),
-            SecretKeys::Expanded(k) => {
-                let mut bytes = k.to_bytes();
-                let key = ExpandedSecretKey::from_bytes(&bytes).map(|k| k.into());
-                bytes.zeroize();
+        // let secret_key: Result<SecretKeys, _> = match &self.secret_key {
+        //     SecretKeys::Normal(k) => SecretKey::from_bytes(k.as_bytes()).map(|k| k.into()),
+        //     SecretKeys::Expanded(k) => {
+        //         let mut bytes = k.to_bytes();
+        //         let key = ExpandedSecretKey::from_bytes(&bytes).map(|k| k.into());
+        //         bytes.zeroize();
 
-                key
-            }
-        };
+        //         key
+        //     }
+        // };
 
-        Self {
-            secret_key: secret_key.expect("Couldn't create a secret key copy."),
-            public_key: self.public_key,
-        }
+        // Self {
+        //     secret_key: secret_key.expect("Couldn't create a secret key copy."),
+        //     public_key: self.public_key,
+        // }
+        Self { secret_key: self.secret_key.clone(), public_key: self.public_key.clone() }
     }
 }
 
@@ -343,26 +365,26 @@ impl From<Ed25519Keypair> for Ed25519KeypairPickle {
     }
 }
 
-impl From<SecretKey> for SecretKeys {
-    fn from(key: SecretKey) -> Self {
-        Self::Normal(Box::new(key))
-    }
-}
+// impl From<SecretKey> for SecretKeys {
+//     fn from(key: SecretKey) -> Self {
+//         Self::Normal(Box::new(key))
+//     }
+// }
 
-impl From<ExpandedSecretKey> for SecretKeys {
-    fn from(key: ExpandedSecretKey) -> Self {
-        Self::Expanded(Box::new(key))
-    }
-}
+// impl From<ExpandedSecretKey> for SecretKeys {
+//     fn from(key: ExpandedSecretKey) -> Self {
+//         Self::Expanded(Box::new(key))
+//     }
+// }
 
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Ed25519KeypairPickle(SecretKeys);
+pub struct Ed25519KeypairPickle(SigningKey);
 
 impl From<Ed25519KeypairPickle> for Ed25519Keypair {
     fn from(pickle: Ed25519KeypairPickle) -> Self {
         let secret_key = pickle.0;
-        let public_key = secret_key.public_key();
+        let public_key = Ed25519PublicKey(secret_key.verifying_key());
 
         Self { secret_key, public_key }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -55,4 +55,6 @@ pub enum KeyError {
     /// resulting shared secret would have been insecure.
     #[error("At least one of the keys did not have contributory behaviour")]
     NonContributoryKey,
+    #[error("Unknown error")]
+    Unknown,
 }


### PR DESCRIPTION
This fork of the vodozemac library helps get around dependancy conflicts. This branch exists to allow development to continue while the supply chain is sorted out .

**What is the issue?**
- Using Vodozemac in a project produces package conflicts due to x25519-dalek's `zeroize` dependency being pined to 1.3 and not being semvar compatible. 
- Updating the curve library results in ed25519 needing to update however introduces breaking changes into vodozemac (namely the removal of ExpandedSecretKey)

This PR updates Vodozemac to ed25519-dalek:2.0.0-rc.2 and resolves conflicts by disabling libolm-compat for use in development while a proper fix is completed by the matrix team. 

**notes:**
- Conflicting code was commented out(rather than deleted) to leave an easier paper trail. 